### PR TITLE
fix: update console dispatch_daily_build not to use docker buildx

### DIFF
--- a/workflows/core/console/dispatch_daily_build.yaml
+++ b/workflows/core/console/dispatch_daily_build.yaml
@@ -23,9 +23,6 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -45,10 +42,10 @@ jobs:
         with:
           context: .
           file: ./apps/web/Dockerfile
-          platforms: linux/amd64,linux/arm64
           build-args: |
             TURBO_TOKEN=${{ secrets.TURBO_TOKEN }}
             TURBO_TEAM=${{ secrets.TURBO_TEAM }}
+            TURBO_API=${{ secrets.TURBO_API }}
           push: true
           tags: |
             cloudforetdev/${{ github.event.repository.name }}:latest

--- a/workflows/core/console/dispatch_release.yaml
+++ b/workflows/core/console/dispatch_release.yaml
@@ -122,9 +122,10 @@ jobs:
             TURBO_API=${{ secrets.TURBO_API }}
           platforms: linux/amd64, linux/arm64
           push: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: ${{ vars.DOCKER_REPO_OWNER }}/${{ github.event.repository.name }}:latest
+          cache-to: type=inline
           tags: |
+            ${{ vars.DOCKER_REPO_OWNER }}/${{ github.event.repository.name }}:latest
             ${{ vars.DOCKER_REPO_OWNER }}/${{ github.event.repository.name }}:${{ env.VERSION }}
             ${{ secrets.ECR_REPO }}/${{ github.event.repository.name }}:latest
             ${{ secrets.ECR_REPO }}/${{ github.event.repository.name }}:${{ env.VERSION }}


### PR DESCRIPTION
# Description

- Updated console dispatch_daily_build not to use docker buildx due to speed issue
- Updated to pass TURBO_API argument when building the docker image
- Updated console dispatch_release not to use gha cache on docker build step