### PR TITLE
feat: delete branch inputs and use default or github.ref_name

### DIFF
--- a/.github/workflows/dispatch_daily_build_all_core_services.yaml
+++ b/.github/workflows/dispatch_daily_build_all_core_services.yaml
@@ -3,8 +3,6 @@ on:
   workflow_dispatch:
 
 env:
-  BRANCH: ${{ github.event.inputs.branch }}
-  VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 jobs:

--- a/.github/workflows/dispatch_release_all_core_services.yaml
+++ b/.github/workflows/dispatch_release_all_core_services.yaml
@@ -2,8 +2,8 @@ name: "[dispatch] release all core services"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'enter branch (only master and release-x.y.z are allowed)'
+      ref_branch:
+        description: 'branch referenced by each repositories (only master and release-x.y.z are allowed)'
         required: true
         default: 'master'
       version:
@@ -20,7 +20,7 @@ on:
 
 env:
   ARCH: ${{ github.event.inputs.container_arch }}
-  BRANCH: ${{ github.event.inputs.branch }}
+  BRANCH: ${{ github.event.inputs.ref_branch }}
   VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 

--- a/.github/workflows/dispatch_release_all_core_services.yaml
+++ b/.github/workflows/dispatch_release_all_core_services.yaml
@@ -35,7 +35,8 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repo: cloudforet-io/console
           workflow: dispatch_release.yaml
-          inputs: '{"branch": "${{ env.BRANCH }}", "version": "${{ env.VERSION }}", "container_arch": "${{ env.ARCH }}"}'
+          ref: ${{ env.BRANCH }}
+          inputs: '{"version": "${{ env.VERSION }}", "container_arch": "${{ env.ARCH }}"}'
 
   core_console_api:
     needs: core_console
@@ -47,7 +48,8 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repo: cloudforet-io/console-api
           workflow: dispatch_release.yaml
-          inputs: '{"branch": "${{ env.BRANCH }}", "version": "${{ env.VERSION }}", "container_arch": "${{ env.ARCH }}"}'
+          ref: ${{ env.BRANCH }}
+          inputs: '{"version": "${{ env.VERSION }}", "container_arch": "${{ env.ARCH }}"}'
 
   core_python_service:
     strategy:
@@ -65,7 +67,8 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repo: cloudforet-io/${{ matrix.target }}
           workflow: dispatch_release.yaml
-          inputs: '{"branch": "${{ env.BRANCH }}", "version": "${{ env.VERSION }}", "container_arch": "${{ env.ARCH }}"}'
+          ref: ${{ env.BRANCH }}
+          inputs: '{"version": "${{ env.VERSION }}", "container_arch": "${{ env.ARCH }}"}'
 
   tools:
     strategy:
@@ -82,7 +85,8 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repo: cloudforet-io/${{ matrix.target }}
           workflow: dispatch_release.yaml
-          inputs: '{"branch": "${{ env.BRANCH }}", "version": "${{ env.VERSION }}", "container_arch": "${{ env.ARCH }}"}'
+          ref: ${{ env.BRANCH }}
+          inputs: '{"version": "${{ env.VERSION }}", "container_arch": "${{ env.ARCH }}"}'
 
   doc:
     strategy:
@@ -99,7 +103,8 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repo: cloudforet-io/${{ matrix.target }}
           workflow: dispatch_release.yaml
-          inputs: '{"branch": "${{ env.BRANCH }}", "version": "${{ env.VERSION }}", "container_arch": "${{ env.ARCH }}"}'
+          ref: ${{ env.BRANCH }}
+          inputs: '{"version": "${{ env.VERSION }}", "container_arch": "${{ env.ARCH }}"}'
 
   notify_to_slack:
     needs: [doc]

--- a/workflows/core/api/dispatch_release.yaml
+++ b/workflows/core/api/dispatch_release.yaml
@@ -3,17 +3,12 @@ name: "[Dispatch] Release"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'enter branch (only master and release-x.y.z are allowed)'
-        required: true
-        default: 'master'
       version:
         description: 'enter version(x.y.z)'
         required: true
         default: '1.0.0'
 
 env:
-  BRANCH: ${{ github.event.inputs.branch }}
   VERSION: ${{ github.event.inputs.version }}
   PACKAGE_VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -25,7 +20,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set python
@@ -93,7 +87,8 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repo: cloudforet-io/api-doc
           workflow: dispatch_release.yaml
-          inputs: '{"branch": "${{ env.BRANCH }}", "version": "${{ env.VERSION }}"}'
+          ref: ${{ env.BRANCH }}
+          inputs: '{"version": "${{ env.VERSION }}"}'
 
   notification:
     needs: build_and_push

--- a/workflows/core/api/dispatch_release.yaml
+++ b/workflows/core/api/dispatch_release.yaml
@@ -87,7 +87,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repo: cloudforet-io/api-doc
           workflow: dispatch_release.yaml
-          ref: ${{ env.BRANCH }}
+          ref: ${{ github.ref_name }}
           inputs: '{"version": "${{ env.VERSION }}"}'
 
   notification:

--- a/workflows/core/api/dispatch_release.yaml
+++ b/workflows/core/api/dispatch_release.yaml
@@ -87,7 +87,7 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}
           repo: cloudforet-io/api-doc
           workflow: dispatch_release.yaml
-          ref: ${{ github.ref_name }}
+          ref: master
           inputs: '{"version": "${{ env.VERSION }}"}'
 
   notification:

--- a/workflows/core/console-api/dispatch_release.yaml
+++ b/workflows/core/console-api/dispatch_release.yaml
@@ -3,10 +3,6 @@ name: "[Dispatch] Release"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'enter branch (only master and release-x.y.z are allowed)'
-        required: true
-        default: 'master'
       version:
         description: 'enter version(x.y.z)'
         required: true
@@ -22,7 +18,6 @@ on:
 
 env:
   ARCH: ${{ github.event.inputs.container_arch }}
-  BRANCH: ${{ github.event.inputs.branch }}
   VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -33,7 +28,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: tagging
@@ -58,7 +52,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up QEMU

--- a/workflows/core/console/dispatch_release.yaml
+++ b/workflows/core/console/dispatch_release.yaml
@@ -17,7 +17,6 @@ on:
 
 
 env:
-  BRANCH: ${{  }}
   ARCH: ${{ github.event.inputs.container_arch }}
   VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/workflows/core/console/dispatch_release.yaml
+++ b/workflows/core/console/dispatch_release.yaml
@@ -3,10 +3,6 @@ name: "[Dispatch] Release"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'enter branch (only master and release-x.y.z are allowed)'
-        required: true
-        default: 'master'
       version:
         description: 'enter version(x.y.z)'
         required: true
@@ -21,8 +17,8 @@ on:
 
 
 env:
+  BRANCH: ${{  }}
   ARCH: ${{ github.event.inputs.container_arch }}
-  BRANCH: ${{ github.event.inputs.branch }}
   VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -38,12 +34,11 @@ jobs:
           repo: ${{ github.event.repository.name }}
           github_token: ${{ secrets.PAT_TOKEN }}
           workflow_file_name: dispatch_versioning.yaml
-          ref: ${{ env.BRANCH }}
           wait_workflow: true
           propagate_failure: true
           wait_interval: 5
           client_payload: '{
-              "branch": "${{ env.BRANCH }}",
+              "branch": "${{ github.ref_name }}",
               "version": "${{ env.VERSION }}"
             }'
 
@@ -59,12 +54,11 @@ jobs:
           repo: ${{ github.event.repository.name }}
           github_token: ${{ secrets.PAT_TOKEN }}
           workflow_file_name: dispatch_mirinae_release.yaml
-          ref: ${{ env.BRANCH }}
           wait_workflow: true
           propagate_failure: true
           wait_interval: 5
           client_payload: '{
-              "branch": "${{ env.BRANCH }}",
+              "branch": "${{ github.ref_name }}",
               "version": "${{ env.VERSION }}"
             }'
 
@@ -79,11 +73,10 @@ jobs:
           repo: ${{ github.event.repository.name }}
           github_token: ${{ secrets.PAT_TOKEN }}
           workflow_file_name: dispatch_storybook_release.yaml
-          ref: ${{ env.BRANCH }}
           wait_workflow: false
           propagate_failure: false
           client_payload: '{
-              "branch": "${{ env.BRANCH }}",
+              "branch": "${{ github.ref_name }}",
               "version": "${{ env.VERSION }}"
             }'
 
@@ -117,7 +110,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           submodules: true
 
       - name: Set up QEMU
@@ -178,7 +170,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
 
       - name: Configure git
         run: |

--- a/workflows/core/python-core/dispatch_release.yaml
+++ b/workflows/core/python-core/dispatch_release.yaml
@@ -3,10 +3,6 @@ name: "[Dispatch] Release"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'enter branch (only master and release-x.y.z are allowed)'
-        required: true
-        default: 'master'
       version:
         description: 'enter version(x.y.z)'
         required: true
@@ -26,7 +22,6 @@ on:
         default: true
 
 env:
-  BRANCH: ${{ github.event.inputs.branch }}
   VERSION: ${{ github.event.inputs.version }}
   PACKAGE_VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -38,7 +33,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: tagging
@@ -63,7 +57,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set python
@@ -104,7 +97,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up QEMU

--- a/workflows/core/python-service/dispatch_release.yaml
+++ b/workflows/core/python-service/dispatch_release.yaml
@@ -3,10 +3,6 @@ name: "[Dispatch] Release"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'enter branch (only master and release-x.y.z are allowed)'
-        required: true
-        default: 'master'
       version:
         description: 'enter version(x.y.z)'
         required: true
@@ -22,7 +18,6 @@ on:
 
 env:
   ARCH: ${{ github.event.inputs.container_arch }}
-  BRANCH: ${{ github.event.inputs.branch }}
   VERSION: ${{ github.event.inputs.version }}
   PACKAGE_VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -34,7 +29,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: tagging
@@ -59,7 +53,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set python
@@ -100,7 +93,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up QEMU

--- a/workflows/doc/api-doc/dispatch_release.yaml
+++ b/workflows/doc/api-doc/dispatch_release.yaml
@@ -3,10 +3,6 @@ name: "[Dispatch] Release"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'enter branch (only master and release-x.y.z are allowed)'
-        required: true
-        default: 'master'
       version:
         description: 'enter version(x.y.z)'
         required: true
@@ -23,7 +19,6 @@ on:
 
 env:
   ARCH: ${{ github.event.inputs.container_arch }}
-  BRANCH: ${{ github.event.inputs.branch }}
   VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -34,7 +29,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Generate markdown files
@@ -64,7 +58,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up QEMU

--- a/workflows/doc/docs/dispatch_release.yaml
+++ b/workflows/doc/docs/dispatch_release.yaml
@@ -3,10 +3,6 @@ name: "[Dispatch] Release"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'enter branch (only master and release-x.y.z are allowed)'
-        required: true
-        default: 'master'
       version:
         description: 'enter version(x.y.z)'
         required: true
@@ -22,7 +18,6 @@ on:
 
 env:
   ARCH: ${{ github.event.inputs.container_arch }}
-  BRANCH: ${{ github.event.inputs.branch }}
   VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -33,7 +28,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: tagging
@@ -58,7 +52,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up QEMU

--- a/workflows/doc/marketplace-assets/dispatch_release.yaml
+++ b/workflows/doc/marketplace-assets/dispatch_release.yaml
@@ -3,10 +3,6 @@ name: "[Dispatch] Release"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'enter branch (only master and release-x.y.z are allowed)'
-        required: true
-        default: 'master'
       version:
         description: 'enter version(x.y.z)'
         required: true
@@ -22,7 +18,6 @@ on:
 
 env:
   ARCH: ${{ github.event.inputs.container_arch }}
-  BRANCH: ${{ github.event.inputs.branch }}
   VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
@@ -33,7 +28,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: tagging
@@ -58,7 +52,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up QEMU
@@ -114,7 +107,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Configure AWS credentials

--- a/workflows/tools/spacectl/dispatch_release.yaml
+++ b/workflows/tools/spacectl/dispatch_release.yaml
@@ -3,10 +3,6 @@ name: "[Dispatch] Release"
 on:
   workflow_dispatch:
     inputs:
-      branch:
-        description: 'enter branch (only master and release-x.y.z are allowed)'
-        required: true
-        default: 'master'
       version:
         description: 'enter version(x.y.z)'
         required: true
@@ -22,7 +18,6 @@ on:
 
 env:
   ARCH: ${{ github.event.inputs.container_arch }}
-  BRANCH: ${{ github.event.inputs.branch }}
   VERSION: ${{ github.event.inputs.version }}
   PACKAGE_VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -34,7 +29,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: tagging
@@ -59,7 +53,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set python
@@ -100,7 +93,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.BRANCH }}
           token: ${{ secrets.PAT_TOKEN }}
 
       - name: Set up QEMU


### PR DESCRIPTION
## description

When cloudforet maintainer try to execute release workflow in micro-service repository, there is two inputs for branch.
But, It can confuse administrators. 

<img width="299" alt="스크린샷 2023-06-02 오후 3 44 39" src="https://github.com/cloudforet-io/actions/assets/19552819/5d236ae0-da1b-4c6c-958e-8614b40dc667">

Therefore, it has been deleted.
Now, we will select branch using only select bar.

![스크린샷 2023-06-02 오후 4 03 20](https://github.com/cloudforet-io/actions/assets/19552819/91990d5c-4373-451e-a1df-81db4ce11057)

## What needs to be reviewed

### dispatch_release.yaml in all core repositories
branch input will be deleted.
But There are some thing that need to be reviewed.

@WANZARGEN 
`console` repository seems to need branch name to trigger other workflow.
So, It is replaced to `${{ github.ref_name }}`. 
it is the short ref name of the branch or tag that triggered the workflow run.

If you'd like to know what `github.ref_name` is, please check [this document](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)

@ImMin5 
`dispatch_release.yaml` in api repository is trigger api-doc release workflow to update our api document.
and this also seems to still require a branch name.

This case has also been changed to `${{ github.ref_name }}`. like console
