### PR TITLE
fix(console): do not use with when values are empty

### DIFF
--- a/workflows/core/console/dispatch_release.yaml
+++ b/workflows/core/console/dispatch_release.yaml
@@ -168,7 +168,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
 
       - name: Configure git
         run: |


### PR DESCRIPTION

There is a problem while using console release action.
 
<img width="1119" alt="image" src="https://github.com/cloudforet-io/actions/assets/26986739/84a8e8fb-017b-41e6-a638-b819a35bdf24">

There seems a problem of using `with` without any values, so this PR removes `with`.
Look [here](https://github.com/cloudforet-io/console/actions/runs/5173252408/workflow) for more information.
