### PR TITLE
fix(console): move versioning logic to docker job

### DIFF
--- a/workflows/core/console/dispatch_release.yaml
+++ b/workflows/core/console/dispatch_release.yaml
@@ -22,28 +22,8 @@ env:
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
 
 jobs:
-  versioning:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Invoke versioning workflow
-        id: versioning
-        uses: convictional/trigger-workflow-and-wait@v1.6.1
-        with:
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          github_token: ${{ secrets.PAT_TOKEN }}
-          workflow_file_name: dispatch_versioning.yaml
-          wait_workflow: true
-          propagate_failure: true
-          wait_interval: 5
-          ref: ${{ github.ref_name }}
-          client_payload: '{
-              "version": "${{ env.VERSION }}"
-            }'
-
   mirinae:
     runs-on: ubuntu-latest
-    needs: versioning
     steps:
       - name: Invoke mirinae release workflow
         id: mirinae
@@ -73,7 +53,7 @@ jobs:
           propagate_failure: false
           ref: ${{ github.ref_name }}
 
-  docker:
+  versioning_and_docker:
     runs-on: ubuntu-latest
     needs: mirinae
 
@@ -104,6 +84,54 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: true
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - name: Restore cached node_modules
+        id: restore-node-cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.OS }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-modules-
+
+      - name: Install dependencies
+        if: steps.restore-node-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Change version
+        run: |
+          converted_version=$(echo ${{ env.VERSION }} | sed -E 's/^([0-9]+\.[0-9]+)\.([a-zA-Z]+)/\1.0-\2/')
+          npm version $converted_version --no-git-tag-version --allow-same-version --no-commit-hooks --include-workspace-root -w=web
+          echo "converted_version=$converted_version" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        run: |
+          git config --global user.email "${{ vars.GIT_EMAIL }}"
+          git config --global user.name "${{ vars.GIT_USERNAME }}"
+
+      - name: Check if there are any changes
+        id: check_changes
+        run: |
+          git diff --exit-code --quiet || echo "::set-output name=changed::true"
+        continue-on-error: true
+
+      - name: Commit changes
+        if: steps.check_changes.outputs.changed == 'true'
+        run: |
+          git commit -am "chore: version ${{ env.VERSION }}"
+
+      - name: Push changes
+        if: steps.check_changes.outputs.changed == 'true'
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.PAT_TOKEN }}
+          branch: ${{ github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
- Change `dispatch_release.yaml`
    - `versioning` job is moved to `docker` job.

https://github.com/GJ-playgroud/sulmo-app/actions/runs/5724726863/job/15511830034


In a workflow, when a code commit is made, other jobs within that workflow cannot retrieve the hash value of the newly applied commit. Due to this reason, you can check that the versioning commit is not being reflected to repository in [here](https://github.com/GJ-playgroud/sulmo-app/actions/runs/5724726863/job/15511830034#step:5:12).

![image](https://github.com/cloudforet-io/actions/assets/50662170/ecf1f08e-2836-4873-b41e-ed4811c1e387)

![image](https://github.com/cloudforet-io/actions/assets/50662170/36a404d9-9afd-4e28-80e9-f94ee536b121)


As a solution, the versioning has been included in the Docker Job to enable operations to be performed within a single runner.