### PR TITLE
Add BRANCH_NAME env and modify default branch for effected step

### DIFF
--- a/workflows/core/api/dispatch_release.yaml
+++ b/workflows/core/api/dispatch_release.yaml
@@ -12,6 +12,7 @@ env:
   VERSION: ${{ github.event.inputs.version }}
   PACKAGE_VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  BRANCH_NAME: ${{ github.ref_name }}
 
 jobs:
   build_and_push:
@@ -21,6 +22,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.PAT_TOKEN }}
+          ref: ${{ env.BRANCH_NAME }}
 
       - name: Set python
         uses: actions/setup-python@v4
@@ -49,10 +51,10 @@ jobs:
           packages-dir: dist/python/dist/
 
 
-      - name: Push artifacts to origin master
+      - name: Push artifacts to ${{ env.BRANCH_NAME }}
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          branch: master
+          branch: ${{ env.BRANCH_NAME }}
           commit_message: "[CI] api has been built"
           commit_user_name: cloudforet-admin
           commit_user_email: admin@cloudforet.io

--- a/workflows/core/api/dispatch_release.yaml
+++ b/workflows/core/api/dispatch_release.yaml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.PAT_TOKEN }}
-          ref: ${{ env.BRANCH_NAME }}
 
       - name: Set python
         uses: actions/setup-python@v4
@@ -54,7 +53,6 @@ jobs:
       - name: Push artifacts to ${{ env.BRANCH_NAME }}
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          branch: ${{ env.BRANCH_NAME }}
           commit_message: "[CI] api has been built"
           commit_user_name: cloudforet-admin
           commit_user_email: admin@cloudforet.io

--- a/workflows/core/python-service/dispatch_release.yaml
+++ b/workflows/core/python-service/dispatch_release.yaml
@@ -21,6 +21,7 @@ env:
   VERSION: ${{ github.event.inputs.version }}
   PACKAGE_VERSION: ${{ github.event.inputs.version }}
   SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+  BRANCH_NAME: ${{ github.ref_name }}
 
 jobs:
   tagging:
@@ -116,6 +117,7 @@ jobs:
           tags: cloudforet/${{ github.event.repository.name }}:${{ env.VERSION }}
           build-args: |
             PACKAGE_VERSION=${{ env.PACKAGE_VERSION }}
+            BRANCH_NAME=${{ env.BRANCH_NAME }} # Only for console-api-v2`
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
### Description
To solving a problem that failures when triggering the Git workflow from a different branch.

- add BRANCH_NAME env
- modify default branch for effected step 