### PR TITLE
Remove comment at build-args

### DIFF
--- a/workflows/core/python-service/dispatch_release.yaml
+++ b/workflows/core/python-service/dispatch_release.yaml
@@ -117,7 +117,7 @@ jobs:
           tags: cloudforet/${{ github.event.repository.name }}:${{ env.VERSION }}
           build-args: |
             PACKAGE_VERSION=${{ env.PACKAGE_VERSION }}
-            BRANCH_NAME=${{ env.BRANCH_NAME }} # Only for console-api-v2`
+            BRANCH_NAME=${{ env.BRANCH_NAME }}
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
### Description

Because of this comment, Dockerfile command was executed like this.
```
RUN git clone --branch release-1.12 # only for console-api-v2 https://github.com/cloudforet-io/api.git:
```
so that comment raised error and this should be removed.