### PR TITLE
Add build-args branch_name when build images for push ECR

### DIFF
--- a/workflows/core/python-service/dispatch_release.yaml
+++ b/workflows/core/python-service/dispatch_release.yaml
@@ -138,6 +138,7 @@ jobs:
           tags: ${{ secrets.ECR_REPO }}/${{ github.event.repository.name }}:${{ env.VERSION }}
           build-args: |
             PACKAGE_VERSION=${{ env.PACKAGE_VERSION }}
+            BRANCH_NAME=${{ env.BRANCH_NAME }}
 
       - name: Notice when job fails
         if: failure()


### PR DESCRIPTION
### Description
Missed to add build-args branch_name when build images for push ECR