### PR TITLE
fix: add PyPI API token to response PyPI 2FA authentication

### DIFF
--- a/workflows/core/api/dispatch_release.yaml
+++ b/workflows/core/api/dispatch_release.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Set python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8' 
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |
@@ -44,8 +44,8 @@ jobs:
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
           packages-dir: dist/python/dist/
 

--- a/workflows/core/python-core/dispatch_release.yaml
+++ b/workflows/core/python-core/dispatch_release.yaml
@@ -78,8 +78,8 @@ jobs:
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
           packages-dir: src/dist/
 

--- a/workflows/core/python-service/dispatch_release.yaml
+++ b/workflows/core/python-service/dispatch_release.yaml
@@ -74,8 +74,8 @@ jobs:
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
           packages-dir: src/dist/
 

--- a/workflows/tools/spacectl/dispatch_release.yaml
+++ b/workflows/tools/spacectl/dispatch_release.yaml
@@ -73,8 +73,8 @@ jobs:
       - name: Publish a Python distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          user: ${{ secrets.PYPI_USERNAME }}
-          password: ${{ secrets.PYPI_PASSWORD }}
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
           verbose: true
           packages-dir: src/dist/
 


### PR DESCRIPTION
SSIA

Existing PYPI authentication cannot be used within workflow because 2FA will soon become essential for pypi authentication. Therefore, in order to cope with this, API token are used instead of authentication using ID PW.